### PR TITLE
タスクフォームにステータス表示を追加し、ステータス色を定義。タスクリストのコンテナをフル幅に変更。

### DIFF
--- a/src/components/TaskForm.vue
+++ b/src/components/TaskForm.vue
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue';
 import type { Task, Status } from '../types/task';
 import { ASSIGNEE_OPTIONS } from '../data/constants';
 import ProcessFlow from './ProcessFlow.vue';
+import { StatusColors } from '../types/task';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -15,8 +16,6 @@ const emit = defineEmits<{
 }>();
 
 const form = ref<Partial<Task>>({});
-
-const selectedStatuses = ref<Status[]>(['not_started', 'pending']);
 
 const resetForm = () => {
   if (props.task) {
@@ -198,6 +197,10 @@ const handleNextAction = async () => {
               <div v-if="form.secondApprovalDate" class="mb-2">
                 <strong>二次承認日時:</strong>
                 {{ new Date(form.secondApprovalDate).toLocaleString('ja-JP') }}
+              </div>
+              <div v-if="form.status" class="mb-2">
+                <strong>ステータス:</strong>
+                <span :style="{ color: StatusColors[form.status] }">{{ form.status }}</span>
               </div>
             </v-card-text>
           </v-card>

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -67,7 +67,7 @@ const getAssigneeName = (value: string) => {
 </script>
 
 <template>
-  <v-container class="bg-cyan-50 min-h-screen py-8">
+  <v-container class="bg-cyan-50 min-h-screen py-8" fluid>
     <v-card class="mx-auto max-w-7xl bg-white shadow-lg rounded-lg">
       <v-card-title class="text-center text-2xl font-bold py-6 bg-cyan-600 text-white">
         タスク管理

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,5 +1,14 @@
 export type Status = 'not_started' | 'pending' | 'first_approval' | 'second_approval' | 'completed' | 'cancelled';
 
+export const StatusColors: Record<Status, string> = {
+  not_started: 'grey',
+  pending: 'blue',
+  first_approval: 'orange',
+  second_approval: 'purple',
+  completed: 'green',
+  cancelled: 'red',
+};
+
 export interface Task {
   id: number;
   title: string;


### PR DESCRIPTION
This pull request includes several changes to the `TaskForm.vue` and `TaskList.vue` components, as well as the `task.ts` type definitions. The changes mainly focus on adding status color mapping and improving the user interface.

### Enhancements to Task Status Display:

* **`src/types/task.ts`**: Added `StatusColors` object to map each task status to a specific color.
* **`src/components/TaskForm.vue`**: Imported `StatusColors` to use in the component.
* **`src/components/TaskForm.vue`**: Displayed the task status with corresponding color in the task form.

### UI Improvements:

* **`src/components/TaskList.vue`**: Made the container fluid to improve layout responsiveness.

### Code Cleanup:

* **`src/components/TaskForm.vue`**: Removed the unused `selectedStatuses` ref.